### PR TITLE
Fixed reconnection issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.5.1 (4/09/2023)
+
+### Bugfixes
+- Fixed address already in use error when server tries to reconnect a client.
+- Sockets are shutdown before closing
+
+### Features
+- All clients and servers have optional argument `stop_reconnect` to add
+a custom function to stop the reconnection loop.
+
+### Tests
+- Integration tests for reconnection.
+
 ## v0.5.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ def __init__(
     reconnect: bool = True,
     timeout: Optional[float] = None,
     stop: Optional[Callable[[], bool]] = None,
+    stop_reconnect: Optional[Callable[[], bool]] = None,
     logger: Optional[logging.Logger] = None,
 )
 ```
@@ -46,6 +47,8 @@ def __init__(
 - `reconnect`: If True, the server will attempt to reconnect after disconnection.
 - `timeout`: Optional timeout value for send and receive operations.
 - `stop`: A function that returns True to signal the server to stop.
+- `stop_reconnect`: A function that returns True to signal the reconnecting loop to stop. Won't have
+any effect if reconnect is set to False.
 - `logger`: Optional logger for logging server events.
 
 #### Properties
@@ -75,6 +78,7 @@ def __init__(
     reconnect: bool = True,
     timeout: Optional[float] = None,
     stop: Optional[Callable[[], bool]] = None,
+    stop_reconnect: Optional[Callable[[], bool]] = None,
     logger: Optional[logging.Logger] = None,
 )
 ```
@@ -84,6 +88,8 @@ def __init__(
 - `reconnect`: If True, the server will attempt to reconnect after disconnection.
 - `timeout`: Optional timeout value for send and receive operations.
 - `stop`: A function that returns True to signal the server to stop.
+- `stop_reconnect`: A function that returns True to signal the reconnecting loop to stop. Won't have
+any effect if reconnect is set to False.
 - `logger`: Optional logger for logging server events.
 
 #### Properties
@@ -116,6 +122,7 @@ def __init__(
     timeout: Optional[float] = None,
     stop_receive: Optional[Callable[[], bool]] = None,
     stop_send: Optional[Callable[[], bool]] = None,
+    stop_reconnect: Optional[Callable[[], bool]] = None,
     logger: Optional[logging.Logger] = None,
 )
 
@@ -128,6 +135,8 @@ def __init__(
 - `timeout`: Optional timeout value for send and receive operations.
 - `stop_receive`:  A function that returns True to signal the receiving loop to stop.
 - `stop_send`:  A function that returns True to signal the sending loop to stop.
+- `stop_reconnect`: A function that returns True to signal the reconnecting loop to stop. Won't have
+any effect if reconnect is set to False.
 - `logger`: Optional logger for logging server events.
 
 #### Properties
@@ -160,6 +169,7 @@ def __init__(
     reconnect: bool = True,
     timeout: Optional[float] = None,
     stop: Optional[Callable[[], bool]] = None,
+    stop_reconnect: Optional[Callable[[], bool]] = None,
     logger: Optional[logging.Logger] = None,
 )
 ```
@@ -169,6 +179,8 @@ def __init__(
 - `reconnect`: If True, the client will attempt to reconnect after disconnection.
 - `timeout`: Optional timeout value for send and receive operations.
 - `stop`: A function that returns True to signal the client to stop.
+- `stop_reconnect`: A function that returns True to signal the reconnecting loop to stop. Won't have
+any effect if reconnect is set to False.
 - `logger`: Optional logger for logging client events.
 
 #### Properties
@@ -196,6 +208,7 @@ def __init__(
     reconnect: bool = True,
     timeout: Optional[float] = None,
     stop: Optional[Callable[[], bool]] = None,
+    stop_reconnect: Optional[Callable[[], bool]] = None,
     logger: Optional[logging.Logger] = None,
 )
 ```
@@ -205,6 +218,8 @@ def __init__(
 - `reconnect`: If True, the client will attempt to reconnect after disconnection.
 - `timeout`: Optional timeout value for send and receive operations.
 - `stop`: A function that returns True to signal the client to stop.
+- `stop_reconnect`: A function that returns True to signal the reconnecting loop to stop. Won't have
+any effect if reconnect is set to False.
 - `logger`: Optional logger for logging client events.
 
 #### Properties
@@ -236,6 +251,7 @@ def __init__(
     timeout: Optional[float] = None,
     stop_receive: Callable[[], bool] = None,
     stop_send: Callable[[], bool] = None,
+    stop_reconnect: Optional[Callable[[], bool]] = None,
     logger: Optional[logging.Logger] = None,
 )
 ```
@@ -246,6 +262,8 @@ def __init__(
 - `timeout`: Optional timeout value for send and receive operations.
 - `stop_receive`: A function that returns True to signal the receiving loop to stop.
 - `stop_send`: A function that returns True to signal the sending loop to stop.
+- `stop_reconnect`: A function that returns True to signal the reconnecting loop to stop. Won't have
+any effect if reconnect is set to False.
 - `logger`: Optional logger for logging client events.
 
 #### Properties
@@ -337,15 +355,17 @@ if __name__ == "__main__":
 
 ```python
 # server.py
-from socketlib import ServerSender
+from socketlib import ServerSender, get_module_logger
 from socketlib.services.samples import MessageGenerator
+
 
 if __name__ == "__main__":
 
     address = ("localhost", 12345)
     server = ServerSender(address)
     
-    msg_gen = MessageGenerator(server.to_send)
+    logger = get_module_logger(__name__, "dev", use_file_handler=False)
+    msg_gen = MessageGenerator(server.to_send, logger)
     
     with server:
         server.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pysocklib"
-version = "0.5.0"
+version = "0.5.1"
 description = "Library to work with socket clients and servers."
 readme = "README.md"
 authors = [{ name = "Daniel Ibarrola", email = "daniel.ibarrola.sanchez@gmail.com" }]
@@ -29,7 +29,7 @@ Homepage = "https://github.com/Daniel-Ibarrola/SocketLib.git"
 socketlib = "socketlib.__main__:main"
 
 [tool.bumpver]
-current_version = "0.5.0"
+current_version = "0.5.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "bump version {old_version} -> {new_version}"
 tag_message = "{new_version}"

--- a/src/socketlib/__init__.py
+++ b/src/socketlib/__init__.py
@@ -4,6 +4,7 @@ from .basic.receive import get_msg, receive_msg
 from .client.client import Client, ClientReceiver, ClientSender
 from .services.abstract_service import AbstractService
 from .server.server import Server, ServerReceiver, ServerSender
-
+from .utils.logger import get_module_logger
+from .utils.watch_dog import WatchDog
 
 __version__ = "0.5.0"

--- a/src/socketlib/__init__.py
+++ b/src/socketlib/__init__.py
@@ -7,4 +7,4 @@ from .server.server import Server, ServerReceiver, ServerSender
 from .utils.logger import get_module_logger
 from .utils.watch_dog import WatchDog
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/src/socketlib/client/client.py
+++ b/src/socketlib/client/client.py
@@ -139,7 +139,10 @@ class ClientBase(abc.ABC):
 
     def close_connection(self) -> None:
         if self._socket is not None:
-            self._socket.shutdown(socket.SHUT_RDWR)
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
             self._socket.close()
 
     def __enter__(self):

--- a/src/socketlib/client/client.py
+++ b/src/socketlib/client/client.py
@@ -59,12 +59,21 @@ class ClientBase(abc.ABC):
     def run_thread(self) -> threading.Thread:
         return self._run_thread
 
+    @property
+    def connect_timeout(self) -> Optional[float]:
+        return self._connect_timeout
+
+    @connect_timeout.setter
+    def connect_timeout(self, timeout: float):
+        self._connect_timeout = timeout
+
     def connect(self, timeout: Optional[float] = None) -> None:
         """ Connect to the server. This will attempt to connect to the server indefinitely
             unless a timeout is given.
 
         """
-        self._connect_timeout = timeout
+        if self.connect_timeout is None:
+            self.connect_timeout = timeout
         connect_thread = threading.Thread(
             target=self._connect_to_server, args=(timeout,), daemon=True
         )

--- a/src/socketlib/client/client.py
+++ b/src/socketlib/client/client.py
@@ -128,6 +128,7 @@ class ClientBase(abc.ABC):
 
     def close_connection(self) -> None:
         if self._socket is not None:
+            self._socket.shutdown(socket.SHUT_RDWR)
             self._socket.close()
 
     def __enter__(self):
@@ -222,6 +223,9 @@ class ClientReceiver(ClientBase):
                 name=self.__class__.__name__
             )
 
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__} exits _recv")
+
 
 class ClientSender(ClientBase):
     """ A client that sends messages to a server"""
@@ -298,6 +302,9 @@ class ClientSender(ClientBase):
                 name=self.__class__.__name__,
                 encoding=self.encoding
             )
+
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__} exits _send")
 
     def start_main_thread(self) -> None:
         """ Start this client in the main thread"""
@@ -397,6 +404,9 @@ class Client(ClientBase):
                 name=self.__class__.__name__
             )
 
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__} exits _send")
+
     def _recv(self) -> None:
         self._wait_for_connection.wait()
         if self._reconnect:
@@ -421,6 +431,9 @@ class Client(ClientBase):
                 logger=self._logger,
                 name=self.__class__.__name__
             )
+
+        if self._logger:
+            self._logger.debug(f"{self.__class__.__name__} exits _recv")
 
     def start(self) -> None:
         """ Start this client in a new thread. """

--- a/src/socketlib/exceptions/exceptions.py
+++ b/src/socketlib/exceptions/exceptions.py
@@ -1,0 +1,3 @@
+
+class FailedToReconnect(OSError):
+    pass

--- a/tests/integration/test_reconnect.py
+++ b/tests/integration/test_reconnect.py
@@ -13,7 +13,7 @@ from socketlib import (
 
 
 def put_msgs_in_queue(messages: queue.Queue[str]) -> None:
-    for ii in range(50):
+    for ii in range(500):
         messages.put(f"msg {ii}")
 
 

--- a/tests/integration/test_reconnect.py
+++ b/tests/integration/test_reconnect.py
@@ -1,19 +1,27 @@
 import queue
 import pytest
 import random
+import threading
 import time
-from socketlib import ServerReceiver, ClientSender, get_module_logger
+from socketlib import (
+    ClientSender,
+    ClientReceiver,
+    ServerReceiver,
+    ServerSender,
+    get_module_logger
+)
 
 
-class TestServerSenderReconnects:
+class TestServerReconnects:
 
     address1 = "localhost", random.randint(1024, 49150)
+    address2 = "localhost", random.randint(1024, 49150)
     logger = get_module_logger("Test", "dev", use_file_handler=False)
 
     def get_client_sender(self, msg: str) -> ClientSender:
         to_send = queue.Queue()
         to_send.put(msg)
-        client = ClientSender(
+        return ClientSender(
             address=self.address1,
             to_send=to_send,
             reconnect=False,
@@ -22,8 +30,6 @@ class TestServerSenderReconnects:
             logger=self.logger
         )
 
-        return client
-
     @pytest.fixture
     def client_senders(self) -> tuple[ClientSender, ClientSender]:
         client1 = self.get_client_sender("msg 1")
@@ -31,8 +37,19 @@ class TestServerSenderReconnects:
 
         yield client1, client2
 
-        client1.close_connection()
-        client2.close_connection()
+        # Make sure connection is closed if test fails
+        try:
+            client1.close_connection()
+            client2.close_connection()
+        except OSError:
+            pass
+
+    @staticmethod
+    def wait_for_client(client: ClientReceiver | ClientSender) -> None:
+        client.connect()
+        client.start()
+        client.join()
+        client.close_connection()
 
     @pytest.mark.timeout(3)
     def test_server_receiver_can_reconnect_clients(self, client_senders):
@@ -50,20 +67,197 @@ class TestServerSenderReconnects:
         )
         server.start()
 
-        client1.connect()
-        client1.start()
-        client1.join()
+        self.wait_for_client(client1)
 
         time.sleep(0.2)
 
-        client2.connect()
-        client2.start()
-        client2.join()
+        self.wait_for_client(client2)
 
         server.join()
         assert not server.received.empty()
         assert server.received.get() == b"msg 1"
         assert server.received.get() == b"msg 2"
 
-    def test_server_sender_can_reconnect_clients(self):
-        pass
+    def get_client_receiver(self) -> ClientReceiver:
+        received = queue.Queue()
+        return ClientReceiver(
+            address=self.address2,
+            received=received,
+            timeout=1,
+            reconnect=False,
+            stop=lambda: received.qsize() > 0,
+            logger=self.logger
+        )
+
+    @pytest.fixture()
+    def client_receivers(self):
+        client1 = self.get_client_receiver()
+        client2 = self.get_client_receiver()
+
+        yield client1, client2
+
+        # Make sure connection is closed if test fails
+        try:
+            client1.close_connection()
+            client2.close_connection()
+        except OSError:
+            pass
+
+    @pytest.mark.timeout(3)
+    def test_server_sender_can_reconnect_clients(self, client_receivers):
+        client1, client2 = client_receivers
+
+        to_send = queue.Queue()
+        stop_server = threading.Event()
+        server = ServerSender(
+            address=self.address2,
+            to_send=to_send,
+            reconnect=True,
+            timeout=0.1,
+            stop=lambda: stop_server.is_set(),
+            stop_reconnect=lambda: stop_server.is_set(),
+            logger=self.logger
+        )
+        to_send.put("msg 1")
+        server.start()
+
+        self.wait_for_client(client1)
+
+        to_send.put("msg 2")
+        time.sleep(0.5)
+
+        self.wait_for_client(client2)
+
+        stop_server.set()
+        server.join()
+        assert not client1.received.empty()
+        assert not client2.received.empty()
+
+        assert client1.received.get() == b"msg 1"
+        assert client2.received.get() == b"msg 2"
+
+
+class TestClientReconnects:
+
+    address1 = "localhost", random.randint(1024, 49150)
+    address2 = "localhost", random.randint(1024, 49150)
+    logger = get_module_logger("Test", "dev", use_file_handler=False)
+
+    def get_server_sender(self, msg: str) -> ServerSender:
+        to_send = queue.Queue()
+        to_send.put(msg)
+        return ServerSender(
+            address=self.address1,
+            to_send=to_send,
+            reconnect=False,
+            timeout=0.2,
+            stop=lambda: to_send.empty(),
+            logger=self.logger
+        )
+
+    @pytest.fixture
+    def server_senders(self) -> tuple[ServerSender, ServerSender]:
+        server1 = self.get_server_sender("msg 1")
+        server2 = self.get_server_sender("msg 2")
+
+        yield server1, server2
+
+        # Close connection in case test fails
+        try:
+            server1.close_connection()
+            server2.close_connection()
+        except OSError:
+            pass
+
+    @pytest.mark.timeout(3)
+    def test_client_receiver_can_reconnect(self, server_senders):
+        server1, server2 = server_senders
+        received = queue.Queue()
+        client = ClientReceiver(
+            address=self.address1,
+            received=received,
+            reconnect=True,
+            timeout=0.2,
+            stop=lambda: received.qsize() > 1,
+            stop_reconnect=lambda: received.qsize() > 1,
+            logger=self.logger
+        )
+
+        server1.start()
+        client.connect()
+        client.start()
+
+        server1.join()
+        server1.close_connection()
+        time.sleep(0.2)
+        self.logger.info(f"Server 1 shutdown")
+        assert not client.received.empty()
+
+        server2.start()
+        server2.join()
+        server2.close_connection()
+
+        client.join()
+        assert not client.received.empty()
+        assert client.received.get() == b"msg 1"
+        assert client.received.get() == b"msg 2"
+
+    def get_server_receiver(self):
+        received = queue.Queue()
+        return ServerReceiver(
+            address=self.address1,
+            received=received,
+            reconnect=False,
+            timeout=0.2,
+            stop=lambda: received.qsize() > 0,
+            logger=self.logger
+        )
+
+    @pytest.fixture
+    def server_receivers(self):
+        server1 = self.get_server_receiver()
+        server2 = self.get_server_receiver()
+
+        yield server1, server2
+
+        # Close connection in case test fails
+        try:
+            server1.close_connection()
+            server2.close_connection()
+        except OSError:
+            pass
+
+    @pytest.mark.timeout(3)
+    def test_client_sender_can_reconnect(self, server_receivers):
+        to_send = queue.Queue()
+        to_send.put("msg 1")
+        to_send.put("msg 2")
+        client = ClientSender(
+            address=self.address1,
+            to_send=to_send,
+            reconnect=True,
+            timeout=0.2,
+            stop=lambda: to_send.empty(),
+            stop_reconnect=lambda: to_send.empty(),
+            logger=self.logger
+        )
+
+        server1, server2 = server_receivers
+        server1.start()
+        client.connect()
+
+        server1.join()
+        server1.close_connection()
+        time.sleep(0.2)  # Wait for client to call connect to server method
+
+        server2.start()
+        server2.join()
+        server2.close_connection()
+
+        client.join()
+        assert client.to_send.empty()
+
+        assert not server1.received.empty()
+        assert not server2.received.empty()
+        assert server1.received.get() == b"msg 1"
+        assert server2.received.get() == b"msg 2"

--- a/tests/integration/test_reconnect.py
+++ b/tests/integration/test_reconnect.py
@@ -1,0 +1,69 @@
+import queue
+import pytest
+import random
+import time
+from socketlib import ServerReceiver, ClientSender, get_module_logger
+
+
+class TestServerSenderReconnects:
+
+    address1 = "localhost", random.randint(1024, 49150)
+    logger = get_module_logger("Test", "dev", use_file_handler=False)
+
+    def get_client_sender(self, msg: str) -> ClientSender:
+        to_send = queue.Queue()
+        to_send.put(msg)
+        client = ClientSender(
+            address=self.address1,
+            to_send=to_send,
+            reconnect=False,
+            timeout=0.2,
+            stop=lambda: to_send.empty(),
+            logger=self.logger
+        )
+
+        return client
+
+    @pytest.fixture
+    def client_senders(self) -> tuple[ClientSender, ClientSender]:
+        client1 = self.get_client_sender("msg 1")
+        client2 = self.get_client_sender("msg 2")
+
+        yield client1, client2
+
+        client1.close_connection()
+        client2.close_connection()
+
+    @pytest.mark.timeout(3)
+    def test_server_receiver_can_reconnect_clients(self, client_senders):
+        client1, client2 = client_senders
+
+        received = queue.Queue()
+        server = ServerReceiver(
+            address=self.address1,
+            received=received,
+            reconnect=True,
+            timeout=0.2,
+            stop=lambda: received.qsize() == 2,
+            stop_reconnect=lambda: received.qsize() == 2,
+            logger=self.logger
+        )
+        server.start()
+
+        client1.connect()
+        client1.start()
+        client1.join()
+
+        time.sleep(0.2)
+
+        client2.connect()
+        client2.start()
+        client2.join()
+
+        server.join()
+        assert not server.received.empty()
+        assert server.received.get() == b"msg 1"
+        assert server.received.get() == b"msg 2"
+
+    def test_server_sender_can_reconnect_clients(self):
+        pass


### PR DESCRIPTION
# Description

## Bugfixes
- Fixed address already in use error when server tries to reconnect a client (closes #3 ).
- Sockets are shutdown before closing

## Features
- All clients and servers have optional argument `stop_reconnect` to add
a custom function to stop the reconnection loop.

## Tests
- Integration tests for reconnection.