### PR TITLE
Client can catch timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1 (12/11/2023)
+- Client connect method can catch TimeoutError exception.
+- Client has a new connect_thread property.
+
 ## v0.6.0 (10/09/2023)
 
 ### Features


### PR DESCRIPTION
## Description

Client classes can catch timeout error in connect method. This way the thread running the connect thread won't die in case of timeout errors.

## Changes made

- Client classes have a new property `connect_thread` that returns the thread that handles the connection to the server.